### PR TITLE
Keep up to three empty lines.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,7 +20,7 @@
     "DerivePointerBinding": true,
     "ExperimentalAutoDetectBinPacking": false,
     "IndentCaseLabels": true,
-    "MaxEmptyLinesToKeep": 1,
+    "MaxEmptyLinesToKeep": 3,
     "NamespaceIndentation": "None",
     "ObjCSpaceBeforeProtocolList": true,
     "PenaltyBreakBeforeFirstCallParameter": 19,


### PR DESCRIPTION
Leaving only one empty line may make the code too difficult to read.