### PR TITLE
Pull request

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,7 +14,7 @@
     "BreakBeforeBinaryOperators": false,
     "BreakBeforeTernaryOperators": false,
     "BreakConstructorInitializersBeforeComma": true,
-    "BreakStringLiterals", false,
+    "BreakStringLiterals": false,
     "BinPackParameters": true,
     "ColumnLimit":    90,
     "ConstructorInitializerAllOnOneLineOrOnePerLine": true,

--- a/.clang-format
+++ b/.clang-format
@@ -14,6 +14,7 @@
     "BreakBeforeBinaryOperators": false,
     "BreakBeforeTernaryOperators": false,
     "BreakConstructorInitializersBeforeComma": true,
+    "BreakStringLiterals", false,
     "BinPackParameters": true,
     "ColumnLimit":    90,
     "ConstructorInitializerAllOnOneLineOrOnePerLine": true,


### PR DESCRIPTION
 "BreakStringLiterals" -> false

In order to prevent things like this:
<pre><code>
humoto::config::yaml::Writer cfg_writer(
        std::string("./wpg_") + SOME_DEFINE "_sa"
                                            "ve"
                                            "d."
                                            "yam"
                                            "l");
</code></pre>